### PR TITLE
test(#5): improve test coverage

### DIFF
--- a/src/main/kotlin/de/idealo/security/endpointexporter/processing/RequestMapping.kt
+++ b/src/main/kotlin/de/idealo/security/endpointexporter/processing/RequestMapping.kt
@@ -7,7 +7,7 @@ import org.springframework.web.util.pattern.PathPattern
 data class RequestMapping(
     val urlPattern: PathPattern,
     val httpMethods: Set<HttpMethod>,
-    val responseStatus: HttpStatus? = null,
+    val responseStatus: HttpStatus,
     val requestParameters: List<RequestParameter>,
     val pathVariables: List<PathVariable>,
     val consumes: List<String>,

--- a/src/main/kotlin/de/idealo/security/endpointexporter/processing/RequestParameterProcessor.kt
+++ b/src/main/kotlin/de/idealo/security/endpointexporter/processing/RequestParameterProcessor.kt
@@ -5,7 +5,7 @@ import de.idealo.security.endpointexporter.classreading.type.MethodMetadata
 import de.idealo.security.endpointexporter.classreading.type.ParameterMetadata
 import org.springframework.web.bind.annotation.RequestParam
 
-class RequestParamProcessor : MetadataProcessor<MethodMetadata, RequestMapping.RequestParameter> {
+class RequestParameterProcessor : MetadataProcessor<MethodMetadata, RequestMapping.RequestParameter> {
 
     override fun process(metadata: MethodMetadata): List<RequestMapping.RequestParameter> {
 

--- a/src/test/kotlin/de/idealo/security/endpointexporter/processing/PathVariableProcessorTest.kt
+++ b/src/test/kotlin/de/idealo/security/endpointexporter/processing/PathVariableProcessorTest.kt
@@ -1,0 +1,110 @@
+package de.idealo.security.endpointexporter.processing
+
+import de.idealo.security.endpointexporter.classreading.type.AnnotationMetadata
+import de.idealo.security.endpointexporter.classreading.type.MethodMetadata
+import de.idealo.security.endpointexporter.classreading.type.ParameterMetadata
+import de.idealo.security.endpointexporter.classreading.type.Visibility
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.web.bind.annotation.PathVariable
+
+internal class PathVariableProcessorTest {
+
+    private val pathVariableProcessor = PathVariableProcessor()
+
+    @Test
+    internal fun `should extract PathVariables with implicit name`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = PathVariable::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "required" to false
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val pathVariables = pathVariableProcessor.process(methodMetadata)
+
+        assertThat(pathVariables).hasSize(1)
+        assertThat(pathVariables[0].name).isEqualTo("testParameter")
+        assertThat(pathVariables[0].type).isEqualTo("java.lang.String")
+        assertThat(pathVariables[0].required).isFalse
+    }
+
+    @Test
+    internal fun `should extract PathVariables with explicit name via name attribute`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = PathVariable::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "name" to "testParameterName"
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val pathVariables = pathVariableProcessor.process(methodMetadata)
+
+        assertThat(pathVariables).hasSize(1)
+        assertThat(pathVariables[0].name).isEqualTo("testParameterName")
+        assertThat(pathVariables[0].type).isEqualTo("java.lang.String")
+        assertThat(pathVariables[0].required).isTrue
+    }
+
+    @Test
+    internal fun `should extract PathVariable with explicit name via value attribute`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = PathVariable::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "value" to "testParameterName"
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val pathVariables = pathVariableProcessor.process(methodMetadata)
+
+        assertThat(pathVariables).hasSize(1)
+        assertThat(pathVariables[0].name).isEqualTo("testParameterName")
+        assertThat(pathVariables[0].type).isEqualTo("java.lang.String")
+        assertThat(pathVariables[0].required).isTrue
+    }
+}

--- a/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestMappingProcessorTest.kt
+++ b/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestMappingProcessorTest.kt
@@ -7,18 +7,95 @@ import de.idealo.security.endpointexporter.classreading.type.ParameterMetadata
 import de.idealo.security.endpointexporter.classreading.type.Visibility
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.util.stream.Stream
 
 internal class RequestMappingProcessorTest {
 
     private val requestMappingProcessor = RequestMappingProcessor()
 
     @Test
-    internal fun shouldExtractRequestMappingFromClassMetadata() {
+    internal fun `should extract RequestMapping for GetMapping with RequestParam`() {
+
+        val classMetadata = ClassMetadata(
+            name = "TestClass",
+            annotations = listOf(
+                AnnotationMetadata(
+                    name = Controller::class.qualifiedName!!,
+                    attributes = emptyMap(),
+                    annotations = emptyList()
+                ),
+                AnnotationMetadata(
+                    name = RequestMapping::class.qualifiedName!!,
+                    attributes = mapOf(
+                        "value" to arrayOf("/test")
+                    ),
+                    annotations = emptyList()
+                )
+            ),
+            methods = listOf(
+                MethodMetadata(
+                    name = "testMethod",
+                    visibility = Visibility.PUBLIC,
+                    parameters = listOf(
+                        ParameterMetadata(
+                            name = "testParameter",
+                            type = "java.lang.String",
+                            annotations = listOf(
+                                AnnotationMetadata(
+                                    name = RequestParam::class.qualifiedName!!,
+                                    attributes = emptyMap(),
+                                    annotations = emptyList()
+                                )
+                            )
+                        )
+                    ),
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = RequestMapping::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "value" to arrayOf("/{testParameter}"),
+                                "method" to arrayOf(HttpMethod.GET.name)
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            )
+        )
+
+        val requestMappings = requestMappingProcessor.process(classMetadata)
+
+        assertThat(requestMappings).hasSize(1)
+        assertThat(requestMappings[0].declaringClassName).isEqualTo("TestClass")
+        assertThat(requestMappings[0].methodName).isEqualTo("testMethod")
+        assertThat(requestMappings[0].httpMethods).containsExactly(HttpMethod.GET)
+        assertThat(requestMappings[0].urlPattern.patternString).isEqualTo("/test/{testParameter}")
+        assertThat(requestMappings[0].consumes).containsExactly("*/*")
+        assertThat(requestMappings[0].produces).containsExactly("*/*")
+        assertThat(requestMappings[0].responseStatus).isEqualTo(HttpStatus.OK)
+        assertThat(requestMappings[0].requestParameters).hasSize(1)
+        assertThat(requestMappings[0].requestParameters[0].name).isEqualTo("testParameter")
+        assertThat(requestMappings[0].requestParameters[0].type).isEqualTo("java.lang.String")
+        assertThat(requestMappings[0].requestParameters[0].required).isTrue
+        assertThat(requestMappings[0].requestParameters[0].defaultValue).isNull()
+        assertThat(requestMappings[0].pathVariables).isEmpty()
+    }
+
+    @Test
+    internal fun `should extract RequestMapping for PostMapping with explicit ResponseStatus and PathVariable`() {
 
         val classMetadata = ClassMetadata(
             name = "TestClass",
@@ -48,9 +125,16 @@ internal class RequestMappingProcessorTest {
                     ),
                     annotations = listOf(
                         AnnotationMetadata(
-                            name = GetMapping::class.qualifiedName!!,
+                            name = PostMapping::class.qualifiedName!!,
                             attributes = mapOf(
                                 "value" to arrayOf("/test/{testParameter}")
+                            ),
+                            annotations = emptyList()
+                        ),
+                        AnnotationMetadata(
+                            name = ResponseStatus::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "code" to HttpStatus.CREATED.name
                             ),
                             annotations = emptyList()
                         )
@@ -64,15 +148,102 @@ internal class RequestMappingProcessorTest {
         assertThat(requestMappings).hasSize(1)
         assertThat(requestMappings[0].declaringClassName).isEqualTo("TestClass")
         assertThat(requestMappings[0].methodName).isEqualTo("testMethod")
-        assertThat(requestMappings[0].httpMethods).containsExactly(HttpMethod.GET)
+        assertThat(requestMappings[0].httpMethods).containsExactly(HttpMethod.POST)
         assertThat(requestMappings[0].urlPattern.patternString).isEqualTo("/test/{testParameter}")
         assertThat(requestMappings[0].consumes).containsExactly("*/*")
         assertThat(requestMappings[0].produces).containsExactly("*/*")
-        assertThat(requestMappings[0].responseStatus).isEqualTo(HttpStatus.OK)
+        assertThat(requestMappings[0].responseStatus).isEqualTo(HttpStatus.CREATED)
         assertThat(requestMappings[0].pathVariables).hasSize(1)
         assertThat(requestMappings[0].pathVariables[0].name).isEqualTo("testParameter")
         assertThat(requestMappings[0].pathVariables[0].type).isEqualTo("java.lang.String")
         assertThat(requestMappings[0].pathVariables[0].required).isTrue
         assertThat(requestMappings[0].requestParameters).isEmpty()
+    }
+
+    @Test
+    internal fun `should extract RequestMapping without explicit urlPattern but with explicit consumes and produces attributes`() {
+
+        val classMetadata = ClassMetadata(
+            name = "TestClass",
+            annotations = listOf(
+                AnnotationMetadata(
+                    name = Controller::class.qualifiedName!!,
+                    attributes = emptyMap(),
+                    annotations = emptyList()
+                )
+            ),
+            methods = listOf(
+                MethodMetadata(
+                    name = "testMethod",
+                    visibility = Visibility.PUBLIC,
+                    parameters = emptyList(),
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = PutMapping::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "consumes" to arrayOf(MediaType.APPLICATION_JSON_VALUE),
+                                "produces" to arrayOf(MediaType.TEXT_PLAIN_VALUE)
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            )
+        )
+
+        val requestMappings = requestMappingProcessor.process(classMetadata)
+
+        assertThat(requestMappings).hasSize(1)
+        assertThat(requestMappings[0].urlPattern.patternString).isEqualTo("/")
+        assertThat(requestMappings[0].consumes).containsExactly(MediaType.APPLICATION_JSON_VALUE)
+        assertThat(requestMappings[0].produces).containsExactly(MediaType.TEXT_PLAIN_VALUE)
+    }
+
+    @ParameterizedTest
+    @MethodSource("requestMappingToHttpStatus")
+    internal fun `should extract RequestMapping for all HttpMethods`(requestMappingAnnotationName: String, expectedHttpMethod: HttpMethod) {
+
+        val classMetadata = ClassMetadata(
+            name = "TestClass",
+            annotations = listOf(
+                AnnotationMetadata(
+                    name = Controller::class.qualifiedName!!,
+                    attributes = emptyMap(),
+                    annotations = emptyList()
+                )
+            ),
+            methods = listOf(
+                MethodMetadata(
+                    name = "testMethod",
+                    visibility = Visibility.PUBLIC,
+                    parameters = emptyList(),
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = requestMappingAnnotationName,
+                            attributes = emptyMap(),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            )
+        )
+
+        val requestMappings = requestMappingProcessor.process(classMetadata)
+
+        assertThat(requestMappings).hasSize(1)
+        assertThat(requestMappings[0].httpMethods).containsExactly(expectedHttpMethod)
+    }
+
+    companion object {
+        @JvmStatic
+        fun requestMappingToHttpStatus(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of("org.springframework.web.bind.annotation.GetMapping", HttpMethod.GET),
+                Arguments.of("org.springframework.web.bind.annotation.PostMapping", HttpMethod.POST),
+                Arguments.of("org.springframework.web.bind.annotation.PutMapping", HttpMethod.PUT),
+                Arguments.of("org.springframework.web.bind.annotation.PatchMapping", HttpMethod.PATCH),
+                Arguments.of("org.springframework.web.bind.annotation.DeleteMapping", HttpMethod.DELETE)
+            )
+        }
     }
 }

--- a/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestMappingTest.kt
+++ b/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestMappingTest.kt
@@ -1,0 +1,134 @@
+package de.idealo.security.endpointexporter.processing
+
+import de.idealo.security.endpointexporter.processing.RequestMapping.PathVariable
+import de.idealo.security.endpointexporter.processing.RequestMapping.RequestParameter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.util.pattern.PathPatternParser
+
+internal class RequestMappingTest {
+
+    private val pathPatternParser = PathPatternParser()
+
+    @Test
+    internal fun `should combine RequestMappings`() {
+
+        val classLevelRequestMapping = RequestMapping(
+            urlPattern = pathPatternParser.parse("/test"),
+            httpMethods = emptySet(),
+            responseStatus = HttpStatus.OK,
+            requestParameters = emptyList(),
+            pathVariables = emptyList(),
+            consumes = listOf(MediaType.ALL_VALUE),
+            produces = listOf(MediaType.ALL_VALUE),
+            declaringClassName = "TestClass",
+            methodName = null
+        )
+
+        val methodLevelRequestMapping = RequestMapping(
+            urlPattern = pathPatternParser.parse("/{testId}"),
+            httpMethods = setOf(HttpMethod.POST),
+            responseStatus = HttpStatus.CREATED,
+            requestParameters = listOf(
+                RequestParameter(
+                    name = "testQueryParam",
+                    type = "java.lang.String",
+                    required = true,
+                    defaultValue = null
+                )
+            ),
+            pathVariables = listOf(
+                PathVariable(
+                    name = "testId",
+                    type = "java.lang.String",
+                    required = true
+                )
+            ),
+            consumes = listOf(MediaType.APPLICATION_JSON_VALUE),
+            produces = listOf(MediaType.ALL_VALUE),
+            declaringClassName = "TestClass",
+            methodName = "testMethod"
+        )
+
+        val requestMapping = classLevelRequestMapping.combine(methodLevelRequestMapping)
+
+        assertThat(requestMapping.urlPattern.patternString).isEqualTo("/test/{testId}")
+        assertThat(requestMapping.httpMethods).containsExactly(HttpMethod.POST)
+        assertThat(requestMapping.responseStatus).isEqualTo(HttpStatus.CREATED)
+        assertThat(requestMapping.requestParameters).hasSize(1)
+        assertThat(requestMapping.requestParameters[0].name).isEqualTo("testQueryParam")
+        assertThat(requestMapping.requestParameters[0].type).isEqualTo("java.lang.String")
+        assertThat(requestMapping.requestParameters[0].required).isTrue
+        assertThat(requestMapping.requestParameters[0].defaultValue).isNull()
+        assertThat(requestMapping.pathVariables).hasSize(1)
+        assertThat(requestMapping.pathVariables[0].name).isEqualTo("testId")
+        assertThat(requestMapping.pathVariables[0].type).isEqualTo("java.lang.String")
+        assertThat(requestMapping.pathVariables[0].required).isTrue
+        assertThat(requestMapping.consumes).containsExactly(MediaType.APPLICATION_JSON_VALUE)
+        assertThat(requestMapping.produces).containsExactly(MediaType.ALL_VALUE)
+        assertThat(requestMapping.declaringClassName).isEqualTo("TestClass")
+        assertThat(requestMapping.methodName).isEqualTo("testMethod")
+    }
+
+    @Test
+    internal fun `should normalize RequestMapping without explicit httpMethods`() {
+
+        val requestMapping = RequestMapping(
+            urlPattern = pathPatternParser.parse("/test"),
+            httpMethods = emptySet(),
+            responseStatus = HttpStatus.OK,
+            requestParameters = emptyList(),
+            pathVariables = emptyList(),
+            consumes = listOf(MediaType.ALL_VALUE),
+            produces = listOf(MediaType.ALL_VALUE),
+            declaringClassName = "TestClass",
+            methodName = "testMethod"
+        )
+
+        val normalizedRequestMapping = requestMapping.normalize()
+
+        assertThat(normalizedRequestMapping.urlPattern.patternString).isEqualTo("/test")
+        assertThat(normalizedRequestMapping.httpMethods).containsExactly(*HttpMethod.values())
+        assertThat(normalizedRequestMapping.responseStatus).isEqualTo(HttpStatus.OK)
+        assertThat(normalizedRequestMapping.requestParameters).isEmpty()
+        assertThat(normalizedRequestMapping.pathVariables).isEmpty()
+        assertThat(normalizedRequestMapping.consumes).containsExactly(MediaType.ALL_VALUE)
+        assertThat(normalizedRequestMapping.produces).containsExactly(MediaType.ALL_VALUE)
+        assertThat(normalizedRequestMapping.declaringClassName).isEqualTo("TestClass")
+        assertThat(normalizedRequestMapping.methodName).isEqualTo("testMethod")
+    }
+
+    @Test
+    internal fun `should normalize RequestMapping with explicit httpMethods`() {
+
+        val requestMapping = RequestMapping(
+            urlPattern = pathPatternParser.parse("/test"),
+            httpMethods = setOf(
+                HttpMethod.GET,
+                HttpMethod.POST
+            ),
+            responseStatus = HttpStatus.OK,
+            requestParameters = emptyList(),
+            pathVariables = emptyList(),
+            consumes = listOf(MediaType.ALL_VALUE),
+            produces = listOf(MediaType.ALL_VALUE),
+            declaringClassName = "TestClass",
+            methodName = "testMethod"
+        )
+
+        val normalizedRequestMapping = requestMapping.normalize()
+
+        assertThat(normalizedRequestMapping.urlPattern.patternString).isEqualTo("/test")
+        assertThat(normalizedRequestMapping.httpMethods).containsExactly(HttpMethod.GET, HttpMethod.POST)
+        assertThat(normalizedRequestMapping.responseStatus).isEqualTo(HttpStatus.OK)
+        assertThat(normalizedRequestMapping.requestParameters).isEmpty()
+        assertThat(normalizedRequestMapping.pathVariables).isEmpty()
+        assertThat(normalizedRequestMapping.consumes).containsExactly(MediaType.ALL_VALUE)
+        assertThat(normalizedRequestMapping.produces).containsExactly(MediaType.ALL_VALUE)
+        assertThat(normalizedRequestMapping.declaringClassName).isEqualTo("TestClass")
+        assertThat(normalizedRequestMapping.methodName).isEqualTo("testMethod")
+    }
+}

--- a/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestParameterProcessorTest.kt
+++ b/src/test/kotlin/de/idealo/security/endpointexporter/processing/RequestParameterProcessorTest.kt
@@ -1,0 +1,114 @@
+package de.idealo.security.endpointexporter.processing
+
+import de.idealo.security.endpointexporter.classreading.type.AnnotationMetadata
+import de.idealo.security.endpointexporter.classreading.type.MethodMetadata
+import de.idealo.security.endpointexporter.classreading.type.ParameterMetadata
+import de.idealo.security.endpointexporter.classreading.type.Visibility
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.web.bind.annotation.RequestParam
+
+internal class RequestParameterProcessorTest {
+
+    private val requestParameterProcessor = RequestParameterProcessor()
+
+    @Test
+    internal fun `should extract RequestParameter with implicit name`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = RequestParam::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "required" to false,
+                                "defaultValue" to "testDefaultValue"
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val requestParameters = requestParameterProcessor.process(methodMetadata)
+
+        assertThat(requestParameters).hasSize(1)
+        assertThat(requestParameters[0].name).isEqualTo("testParameter")
+        assertThat(requestParameters[0].type).isEqualTo("java.lang.String")
+        assertThat(requestParameters[0].required).isFalse
+        assertThat(requestParameters[0].defaultValue).isEqualTo("testDefaultValue")
+    }
+
+    @Test
+    internal fun `should extract RequestParameter with explicit name via name attribute`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = RequestParam::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "name" to "testParameterName"
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val requestParameters = requestParameterProcessor.process(methodMetadata)
+
+        assertThat(requestParameters).hasSize(1)
+        assertThat(requestParameters[0].name).isEqualTo("testParameterName")
+        assertThat(requestParameters[0].type).isEqualTo("java.lang.String")
+        assertThat(requestParameters[0].required).isTrue
+        assertThat(requestParameters[0].defaultValue).isNull()
+    }
+
+    @Test
+    internal fun `should extract RequestParameter with explicit name via value attribute`() {
+
+        val methodMetadata = MethodMetadata(
+            name = "testMethod",
+            visibility = Visibility.PUBLIC,
+            parameters = listOf(
+                ParameterMetadata(
+                    name = "testParameter",
+                    type = "java.lang.String",
+                    annotations = listOf(
+                        AnnotationMetadata(
+                            name = RequestParam::class.qualifiedName!!,
+                            attributes = mapOf(
+                                "value" to "testParameterName"
+                            ),
+                            annotations = emptyList()
+                        )
+                    )
+                )
+            ),
+            annotations = emptyList()
+        )
+
+        val requestParameters = requestParameterProcessor.process(methodMetadata)
+
+        assertThat(requestParameters).hasSize(1)
+        assertThat(requestParameters[0].name).isEqualTo("testParameterName")
+        assertThat(requestParameters[0].type).isEqualTo("java.lang.String")
+        assertThat(requestParameters[0].required).isTrue
+        assertThat(requestParameters[0].defaultValue).isNull()
+    }
+}


### PR DESCRIPTION
Improves the test coverage for package `de.idealo.security.endpointexporter.processing`.

Also renames `RequestParamProcessor` to `RequestParameterProcessor` to be consistent with the model class name and makes `RequestMapping#httpMethods` non nullable.