### PR TITLE
fix: update dependencies

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.4</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -39,7 +39,7 @@
         <java.version>11</java.version>
 
         <asm.version>9.4</asm.version>
-        <swagger.version>2.2.3</swagger.version>
+        <swagger.version>2.2.4</swagger.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
build(deps): bump amannn/action-semantic-pull-request from 4 to 5.0.2

Bumps [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) from 4 to 5.0.2.
- [Release notes](https://github.com/amannn/action-semantic-pull-request/releases)
- [Changelog](https://github.com/amannn/action-semantic-pull-request/blob/main/CHANGELOG.md)
- [Commits](https://github.com/amannn/action-semantic-pull-request/compare/v4...v5.0.2)

---
updated-dependencies:
- dependency-name: amannn/action-semantic-pull-request dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump swagger.version from 2.2.3 to 2.2.4

Bumps `swagger.version` from 2.2.3 to 2.2.4.

Updates `swagger-core` from 2.2.3 to 2.2.4
- [Release notes](https://github.com/swagger-api/swagger-core/releases)
- [Commits](https://github.com/swagger-api/swagger-core/compare/v2.2.3...v2.2.4)

Updates `swagger-models` from 2.2.3 to 2.2.4

---
updated-dependencies:
- dependency-name: io.swagger.core.v3:swagger-core dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.swagger.core.v3:swagger-models dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump spring-boot-starter-parent from 2.7.4 to 2.7.5

Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 2.7.4 to 2.7.5.
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.7.4...v2.7.5)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-starter-parent dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>