### PR TITLE
chore: use new arm compatible docker image builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-13
+          - macos-latest
     name: Verify ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-13
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <configuration>
                     <image>
                         <name>${image.name}</name>
-                        <builder>paketobuildpacks/builder-jammy-tiny:0.0.247</builder>
+                        <builder>paketobuildpacks/builder-jammy-java-tiny:0.0.23</builder>
                         <env>
                             <BP_OCI_SOURCE>${project.scm.url}</BP_OCI_SOURCE>
                             <BP_JVM_VERSION>21</BP_JVM_VERSION> <!-- required so that GraalVM 21 is used -->
@@ -202,23 +202,6 @@
                                 <!-- Workaround for https://github.com/oracle/graal/issues/6957 -->
                                 <arg>--strict-image-heap</arg>
                             </buildArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>arm64</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <configuration>
-                            <image>
-                                <!-- Might be obsolete soon as https://github.com/paketo-buildpacks/native-image/releases/tag/v5.13.0 introduced arm support -->
-                                <builder>dashaun/builder:tiny</builder>
-                            </image>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Note, that the image we're releasing is still only compatible with amd64. However, it is possible to build arm compatible images from source now.