### PR TITLE
fix: fix endpoints rewrite with same path and different HTTP methods

### DIFF
--- a/src/main/kotlin/de/idealo/security/endpointexporter/export/ExportService.kt
+++ b/src/main/kotlin/de/idealo/security/endpointexporter/export/ExportService.kt
@@ -87,10 +87,10 @@ class ExportService {
             )
 
             requestMapping.httpMethods.forEach { httpMethod ->
-                paths.addPathItem(
-                    requestMapping.urlPattern.patternString,
-                    mapHttpMethodToOperation(httpMethod).invoke(PathItem(), operation)
-                )
+                val pathString = requestMapping.urlPattern.patternString
+                val existingPathItem = paths.get(pathString) ?: PathItem()
+                mapHttpMethodToOperation(httpMethod).invoke(existingPathItem, operation)
+                paths.addPathItem(pathString, existingPathItem)
             }
         }
 


### PR DESCRIPTION
We can fix this [issue](https://github.com/idealo/spring-endpoint-exporter/issues/206) like in this PR 